### PR TITLE
fix: renovate config, add pre-commit linter

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,8 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>ivuorinen/renovate-config",
-    "config:recommended"
+    "github>ivuorinen/renovate-config"
   ],
   "labels": [
     "dependencies"
@@ -13,11 +12,10 @@
   "semanticCommitType": "chore",
   "semanticCommitScope": "deps",
   "postUpdateOptions": [
-    "gomodTidy"
+    "gomodUpdateImportPaths"
   ],
-  "golang": {
-    "enabled": true,
-    "gomodUpdateImportPaths": true
+  "gomod": {
+    "enabled": true
   },
   "packageRules": [
     {
@@ -48,10 +46,6 @@
       "groupName": "golang.org/x packages"
     }
   ],
-  "schedule": [
-    "before 4am on monday"
-  ],
-  "timezone": "UTC",
   "prConcurrentLimit": 3,
   "prHourlyLimit": 2
 }

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -76,15 +76,15 @@ formatters:
     gofmt:
       simplify: true
       rewrite-rules:
-        - pattern: 'interface{}'
-          replacement: 'any'
-        - pattern: 'a[b:len(a)]'
-          replacement: 'a[b:]'
+        - pattern: "interface{}"
+          replacement: "any"
+        - pattern: "a[b:len(a)]"
+          replacement: "a[b:]"
     goimports:
       local-prefixes:
         - github.com/ivuorinen/gh-action-readme
 
 issues:
-  max-issues-per-linter: 50
-  max-same-issues: 3
+  max-issues-per-linter: 150
+  max-same-issues: 50
   fix: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,12 @@ repos:
       - id: pretty-format-json
         args: [--autofix, --no-sort-keys]
 
+  # Renovatebot pre-commit hooks
+  - repo: https://github.com/renovatebot/pre-commit-hooks
+    rev: 41.56.1
+    hooks:
+      - id: renovate-config-validator
+
   # YAML formatting with yamlfmt (replaces yamllint for formatting)
   - repo: https://github.com/google/yamlfmt
     rev: v0.17.2
@@ -37,7 +43,7 @@ repos:
     rev: v0.18.1
     hooks:
       - id: markdownlint-cli2
-        exclude: '^testdata/'
+        exclude: "^testdata/"
 
   # EditorConfig checking
   - repo: https://github.com/editorconfig-checker/editorconfig-checker


### PR DESCRIPTION
This pull request updates project configuration files to improve dependency management, code formatting, and pre-commit validation. The most significant changes involve refining Renovate and GolangCI-Lint settings, and adding a Renovate config validator to pre-commit hooks.

**Renovate configuration improvements:**
* Removed the `"config:recommended"` preset from the `extends` array in `.github/renovate.json`, so now only the custom config is used.
* Changed the `postUpdateOptions` from `"gomodTidy"` to `"gomodUpdateImportPaths"` and replaced the `golang` section with a `gomod` section for better Go module update handling.
* Removed the scheduled update window and timezone settings, allowing Renovate to run without time restrictions.

**Linting and formatting adjustments:**
* Increased `max-issues-per-linter` from 50 to 150 and `max-same-issues` from 3 to 50 in `.golangci.yml` to allow more issues before failing, and switched YAML quoting style in rewrite rules for consistency.

**Pre-commit hook enhancements:**
* Added the `renovate-config-validator` hook from the Renovatebot pre-commit hooks to ensure Renovate configuration validity.
* Updated the `exclude` pattern for `markdownlint-cli2` to use double quotes for consistency.