### PR TITLE
fix(ci): add build step to security workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -97,6 +97,16 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
+      - name: Set up Go
+        uses: actions/setup-go@v5 # v5.5.0
+        with:
+          go-version-file: 'go.mod'
+          check-latest: true
+
+      - name: Build the bin
+        shell: bash
+        run: make build
+
       - name: Build Docker image
         run: docker build -t gh-action-readme:test .
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -98,7 +98,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Set up Go
-        uses: actions/setup-go@v5 # v5.5.0
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
         with:
           go-version-file: 'go.mod'
           check-latest: true


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for security checks by adding steps to set up the Go environment and build the project binary before building the Docker image. This ensures that the Go dependencies are correctly installed and the binary is built as part of the CI process.

CI workflow improvements:

* Added a step to set up the Go environment using `actions/setup-go@v5` with the Go version specified in `go.mod`, ensuring the latest compatible Go version is used.
* Added a step to build the project binary using `make build` before the Docker image is built, ensuring the binary is available for inclusion in the Docker image.