### PR TITLE
fix(ci): update goreleaser

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
-          version: latest
-          args: --timeout=5m
-      - name: Install dependencies
-        run: go mod tidy
+          version: v2.7.2
       - name: Setup Node.js for EditorConfig tools
         uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,11 @@ jobs:
           fetch-depth: 0
       - name: Set up Go
         uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
+        with:
+          version: latest
+          args: --timeout=5m
       - name: Install dependencies
         run: go mod tidy
       - name: Setup Node.js for EditorConfig tools

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -45,11 +45,11 @@ builds:
 
 archives:
   - id: default
-    format: tar.gz
+    formats: [tar.gz]
     # Use zip for Windows
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [zip]
     name_template: >-
       {{ .ProjectName }}_ {{- title .Os }}_ {{- if eq .Arch "amd64" }}x86_64 {{- else if eq .Arch "386" }}i386 {{- else }}{{ .Arch }}{{ end }} {{- if .Arm }}v{{ .Arm }}{{ end }}
     files:
@@ -64,7 +64,7 @@ checksum:
   name_template: 'checksums.txt'
 
 snapshot:
-  name_template: "{{ incpatch .Version }}-next"
+  version_template: "{{ incpatch .Version }}-next"
 
 changelog:
   sort: asc
@@ -144,29 +144,31 @@ release:
     Thanks to all contributors who made this release possible!
 
 # Homebrew tap
-brews:
-  - name: gh-action-readme
-    homepage: https://github.com/ivuorinen/gh-action-readme
-    description: "Auto-generate beautiful README and HTML documentation for GitHub Actions"
-    license: MIT
-    repository:
-      owner: ivuorinen
-      name: homebrew-tap
-      branch: main
-      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
-    directory: Formula
-    commit_author:
-      name: goreleaserbot
-      email: bot@goreleaser.com
-    commit_msg_template: "Brew formula update for {{ .ProjectName }} version {{ .Tag }}"
-    install: |
-      bin.install "gh-action-readme"
-
-      # Install templates and schemas
-      (share/"gh-action-readme/templates").install Dir["templates/*"]
-      (share/"gh-action-readme/schemas").install Dir["schemas/*"]
-    test: |
-      system "#{bin}/gh-action-readme", "version"
+# TODO: Re-enable once we can properly support homebrew_casks with data files
+# or find an alternative packaging solution for templates/schemas
+# brews:
+#   - name: gh-action-readme
+#     homepage: https://github.com/ivuorinen/gh-action-readme
+#     description: "Auto-generate beautiful README and HTML documentation for GitHub Actions"
+#     license: MIT
+#     repository:
+#       owner: ivuorinen
+#       name: homebrew-tap
+#       branch: main
+#       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+#     directory: Formula
+#     commit_author:
+#       name: goreleaserbot
+#       email: bot@goreleaser.com
+#     commit_msg_template: "Brew formula update for {{ .ProjectName }} version {{ .Tag }}"
+#     install: |
+#       bin.install "gh-action-readme"
+#
+#       # Install templates and schemas
+#       (share/"gh-action-readme/templates").install Dir["templates/*"]
+#       (share/"gh-action-readme/schemas").install Dir["schemas/*"]
+#     test: |
+#       system "#{bin}/gh-action-readme", "version"
 
 # Scoop bucket for Windows (disabled - repository doesn't exist)
 # scoops:
@@ -183,50 +185,23 @@ brews:
 #       email: bot@goreleaser.com
 #     commit_msg_template: "Scoop update for {{ .ProjectName }} version {{ .Tag }}"
 
-# Docker images
-dockers:
-  - image_templates:
-      - "ghcr.io/ivuorinen/gh-action-readme:{{ .Version }}-amd64"
-      - "ghcr.io/ivuorinen/gh-action-readme:latest-amd64"
+# Docker images (using dockers_v2 with multi-platform buildx)
+dockers_v2:
+  - images:
+      - "ghcr.io/ivuorinen/gh-action-readme"
+    tags:
+      - "{{ .Version }}"
+      - "latest"
     dockerfile: Dockerfile
-    use: buildx
-    build_flag_templates:
-      - "--pull"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title={{.ProjectName}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-      - "--label=org.opencontainers.image.source=https://github.com/ivuorinen/gh-action-readme"
-      - "--platform=linux/amd64"
-    goos: linux
-    goarch: amd64
-
-  - image_templates:
-      - "ghcr.io/ivuorinen/gh-action-readme:{{ .Version }}-arm64"
-      - "ghcr.io/ivuorinen/gh-action-readme:latest-arm64"
-    dockerfile: Dockerfile
-    use: buildx
-    build_flag_templates:
-      - "--pull"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title={{.ProjectName}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-      - "--label=org.opencontainers.image.source=https://github.com/ivuorinen/gh-action-readme"
-      - "--platform=linux/arm64"
-    goos: linux
-    goarch: arm64
-
-docker_manifests:
-  - name_template: "ghcr.io/ivuorinen/gh-action-readme:{{ .Version }}"
-    image_templates:
-      - "ghcr.io/ivuorinen/gh-action-readme:{{ .Version }}-amd64"
-      - "ghcr.io/ivuorinen/gh-action-readme:{{ .Version }}-arm64"
-
-  - name_template: "ghcr.io/ivuorinen/gh-action-readme:latest"
-    image_templates:
-      - "ghcr.io/ivuorinen/gh-action-readme:latest-amd64"
-      - "ghcr.io/ivuorinen/gh-action-readme:latest-arm64"
+    platforms:
+      - linux/amd64
+      - linux/arm64
+    labels:
+      org.opencontainers.image.created: "{{.Date}}"
+      org.opencontainers.image.title: "{{.ProjectName}}"
+      org.opencontainers.image.revision: "{{.FullCommit}}"
+      org.opencontainers.image.version: "{{.Version}}"
+      org.opencontainers.image.source: "https://github.com/ivuorinen/gh-action-readme"
 
 # Signing
 signs:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,8 +10,6 @@ before:
   hooks:
     # Run tests before building
     - go test ./...
-    # Run linter
-    - golangci-lint run
     # Ensure dependencies are tidy
     - go mod tidy
 


### PR DESCRIPTION
This pull request updates the CI and release configuration to improve build, linting, and packaging processes for the project. The main changes include switching to `golangci-lint` for linting in CI, updating Docker image builds to use multi-platform support, and making adjustments to release packaging and templates. Homebrew support is temporarily disabled pending a better solution for packaging data files.

**CI and Linting Improvements**
* Replaced the manual Go dependency installation step in `.github/workflows/ci.yml` with the `golangci-lint` GitHub Action for linting, ensuring consistent lint checks in CI.
* Removed the linter invocation from the `before` hooks in `.goreleaser.yaml` to avoid redundant linting during release builds.

**Release Packaging Adjustments**
* Updated archive and format definitions in `.goreleaser.yaml` to use the `formats` array for better compatibility with GoReleaser's latest schema.
* Changed the `snapshot` section to use `version_template` instead of `name_template` for clarity and correctness.

**Distribution Changes**
* Commented out the Homebrew tap configuration in `.goreleaser.yaml` with a note explaining the temporary removal due to issues packaging templates and schemas.

**Docker Build Modernization**
* Migrated from the old `dockers` and `docker_manifests` sections to the new `dockers_v2` format in `.goreleaser.yaml`, enabling multi-platform builds and consolidated image tagging.