### PR TITLE
fix(ci): update security workflow to match goreleaser paths

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -116,17 +116,23 @@ jobs:
       - name: Build the bin
         shell: bash
         run: |
-          # Create platform-specific directory structure (matching GoReleaser)
-          mkdir -p linux/amd64
+          # Auto-detect platform (matching GoReleaser's structure)
+          PLATFORM="$(go env GOOS)/$(go env GOARCH)"
 
-          # Build binary into the platform directory (ubuntu-latest is amd64)
-          GOOS=linux GOARCH=amd64 go build -o linux/amd64/gh-action-readme .
+          # Create platform-specific directory structure
+          mkdir -p "$PLATFORM"
+
+          # Build binary into the platform directory
+          go build -o "$PLATFORM/gh-action-readme" .
 
           # Verify binary was created
-          ls -lh linux/amd64/gh-action-readme
+          ls -lh "$PLATFORM/gh-action-readme"
+
+          # Export platform for Docker build step
+          echo "TARGETPLATFORM=$PLATFORM" >> "$GITHUB_ENV"
 
       - name: Build Docker image
-        run: docker build -t gh-action-readme:test .
+        run: docker build --build-arg TARGETPLATFORM=${{ env.TARGETPLATFORM }} -t gh-action-readme:test .
 
       - name: Run Trivy vulnerability scanner on Docker image
         uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -115,7 +115,15 @@ jobs:
 
       - name: Build the bin
         shell: bash
-        run: make build
+        run: |
+          # Create platform-specific directory structure (matching GoReleaser)
+          mkdir -p linux/amd64
+
+          # Build binary into the platform directory (ubuntu-latest is amd64)
+          GOOS=linux GOARCH=amd64 go build -o linux/amd64/gh-action-readme .
+
+          # Verify binary was created
+          ls -lh linux/amd64/gh-action-readme
 
       - name: Build Docker image
         run: docker build -t gh-action-readme:test .

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@
 FROM scratch
 
 # Multi-platform build support
+# See: https://goreleaser.com/customization/dockers_v2/
+# GoReleaser organizes binaries in platform subdirectories (linux/amd64/, linux/arm64/)
+# TARGETPLATFORM arg resolves to the correct platform directory
 ARG TARGETPLATFORM
 
 # Copy the binary from the build context (platform-specific)


### PR DESCRIPTION
This pull request updates the build process in the GitHub Actions workflow and Dockerfile to better support multi-platform builds, aligning with GoReleaser's directory structure. The main improvements are in how the binary is built and passed into the Docker image, ensuring compatibility with different platforms.

**Build process improvements:**

* The build step in `.github/workflows/security.yml` now auto-detects the platform using `go env`, creates a platform-specific directory (e.g., `linux/amd64`), and builds the binary into this directory to match GoReleaser's structure.
* The Docker build step now uses the `TARGETPLATFORM` build argument, which references the platform-specific directory, ensuring the correct binary is included in the image.

**Dockerfile enhancements:**

* Added comments and the `TARGETPLATFORM` build argument to the `Dockerfile` to clarify how multi-platform binaries are handled and to match GoReleaser's organization.