### PR TITLE
fix(ci): remove vestigial template copying from Docker builds

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -57,9 +57,6 @@ archives:
       - LICENSE*
       - CHANGELOG.md
       - docs/*.md
-      - templates/*.tmpl
-      - templates/themes/**/*.tmpl
-      - templates/themes/**/*.adoc
       - schemas/*.json
 
 checksum:
@@ -199,7 +196,6 @@ dockers_v2:
       - linux/amd64
       - linux/arm64
     extra_files:
-      - templates
       - schemas
     labels:
       org.opencontainers.image.created: "{{.Date}}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,12 +10,10 @@ ARG TARGETPLATFORM
 # Copy the binary from the build context (platform-specific)
 COPY $TARGETPLATFORM/gh-action-readme /usr/local/bin/gh-action-readme
 
-# Copy templates and schemas
-COPY templates /usr/local/share/gh-action-readme/templates
+# Copy schemas (templates are embedded in the binary via go:embed)
 COPY schemas /usr/local/share/gh-action-readme/schemas
 
-# Set environment variables for template paths
-ENV GH_ACTION_README_TEMPLATE_PATH=/usr/local/share/gh-action-readme/templates
+# Set environment variable for schema path
 ENV GH_ACTION_README_SCHEMA_PATH=/usr/local/share/gh-action-readme/schemas
 
 # Set the binary as entrypoint


### PR DESCRIPTION
Templates are embedded in the binary via go:embed directive and don't need to be copied as external files. Removing COPY and ENV directives for templates from Dockerfile and template file patterns from GoReleaser.

Changes:
- Remove COPY templates from Dockerfile (was failing: directory doesn't exist)
- Remove ENV GH_ACTION_README_TEMPLATE_PATH (never used in code)
- Remove template file patterns from GoReleaser archives
- Remove templates from GoReleaser extra_files
- Keep schemas (still used in config)

Fixes:
- Docker image builds now succeed
- No 'no files matched' warnings from GoReleaser
- Release workflow can complete successfully
- Binary uses embedded templates at runtime