### PR TITLE
ci: migrate CodeQL to ivuorinen/actions/codeql-analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,24 +1,26 @@
 ---
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 name: "CodeQL"
+
 on:
   push:
     branches: ["main"]
   pull_request:
     branches: ["main"]
   schedule:
-    - cron: "    - cron: "30 1 * * 0" # Run at 1:30 AM UTC every Sunday"
+    - cron: "30 1 * * 0"
   merge_group:
 
-permissions:
-  actions: read
-  contents: read
+permissions: {}
 
 jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
     permissions:
+      actions: read
+      contents: read
+      packages: read
       security-events: write
     strategy:
       fail-fast: false
@@ -26,6 +28,7 @@ jobs:
         language: ["actions", "go"]
     steps:
       - name: CodeQL Analysis
-        uses: ivuorinen/actions/codeql-analysis@main
+        uses: ivuorinen/actions/codeql-analysis@97105fc2a909360678588cb50caf0be5144be486 # v2026.03.06
         with:
           language: ${{ matrix.language }}
+          queries: security-and-quality

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,14 +1,13 @@
 ---
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 name: "CodeQL"
-
 on:
   push:
     branches: ["main"]
   pull_request:
     branches: ["main"]
   schedule:
-    - cron: "30 1 * * 0" # Run at 1:30 AM UTC every Sunday
+    - cron: "    - cron: "30 1 * * 0" # Run at 1:30 AM UTC every Sunday"
   merge_group:
 
 permissions:
@@ -21,28 +20,12 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       security-events: write
-
     strategy:
       fail-fast: false
       matrix:
-        language: ["go"]
-
+        language: ["actions", "go"]
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: CodeQL Analysis
+        uses: ivuorinen/actions/codeql-analysis@main
         with:
-          fetch-depth: 0
-
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@0d579ffd059c29b07949a3cce3983f0780820c98 # v4.32.6
-        with:
-          languages: ${{ matrix.language }}
-          queries: security-and-quality
-
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@0d579ffd059c29b07949a3cce3983f0780820c98 # v4.32.6
-
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@0d579ffd059c29b07949a3cce3983f0780820c98 # v4.32.6
-        with:
-          category: "/language:${{matrix.language}}"
+          language: ${{ matrix.language }}


### PR DESCRIPTION
Migrate from direct `github/codeql-action` usage to the centralized
`ivuorinen/actions/codeql-analysis` composable workflow.

This eliminates repetitive Renovate PRs for CodeQL action version bumps
by centralizing version management in the shared actions repo.