### PR TITLE
ci: enforce least-privilege permissions and update workflow dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,14 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+
+permissions: {}
+
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,7 +28,7 @@ jobs:
         language: ["actions", "go"]
     steps:
       - name: CodeQL Analysis
-        uses: ivuorinen/actions/codeql-analysis@97105fc2a909360678588cb50caf0be5144be486 # v2026.03.06
+        uses: ivuorinen/actions/codeql-analysis@4360ea39c744dbd52bf1d624bf058ba4dd81245a # v2026.03.09
         with:
           language: ${{ matrix.language }}
           queries: security-and-quality

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -9,13 +9,14 @@ on:
     branches:
       - main
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   commitlint:
     name: Validate Commit Messages
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -12,8 +12,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   Linter:
@@ -31,4 +30,4 @@ jobs:
     steps:
       - name: Run PR Lint
         # https://github.com/ivuorinen/actions
-        uses: ivuorinen/actions/pr-lint@6e8f2aae9d0846d901d9eba15b8e94a2900573dc # v2026.03.02
+        uses: ivuorinen/actions/pr-lint@4360ea39c744dbd52bf1d624bf058ba4dd81245a # v2026.03.09

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,8 +6,7 @@ on:
     tags:
       - "v*.*.*"
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   release:
@@ -33,18 +32,18 @@ jobs:
           node-version: "24"
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
+        uses: sigstore/cosign-installer@ba7bc0a3fef59531c69a25acd34668d6d3fe6f22 # v4.1.0
         with:
           cosign-release: "v2.4.0"
 
       - name: Install syft
-        uses: anchore/sbom-action/download-syft@17ae1740179002c89186b61233e0f892c3118b11 # v0.23.0
+        uses: anchore/sbom-action/download-syft@57aae528053a48a3f6235f2d9461b05fbcb7366d # v0.23.1
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -12,6 +12,8 @@ on:
     - cron: "0 2 * * 0"
   merge_group:
 
+permissions: {}
+
 jobs:
   # Comprehensive security coverage:
   # - govulncheck: Go-specific vulnerability scanning
@@ -45,7 +47,7 @@ jobs:
     name: Trivy Security Scan
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write # needed for Dependency Submission API (SBOM)
       security-events: write
     steps:
       - name: Checkout repository

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -8,10 +8,7 @@ on:
   workflow_call:
   workflow_dispatch:
 
-permissions:
-  contents: read
-  packages: read
-  statuses: read
+permissions: {}
 
 jobs:
   stale:
@@ -23,4 +20,4 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: ivuorinen/actions/stale@6e8f2aae9d0846d901d9eba15b8e94a2900573dc # v2026.03.02
+      - uses: ivuorinen/actions/stale@4360ea39c744dbd52bf1d624bf058ba4dd81245a # v2026.03.09

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -20,8 +20,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   labels:
@@ -40,4 +39,4 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: ⤵️ Sync Latest Labels Definitions
-        uses: ivuorinen/actions/sync-labels@6e8f2aae9d0846d901d9eba15b8e94a2900573dc # v2026.03.02
+        uses: ivuorinen/actions/sync-labels@4360ea39c744dbd52bf1d624bf058ba4dd81245a # v2026.03.09

--- a/testdata/composite-action/action.yml
+++ b/testdata/composite-action/action.yml
@@ -18,13 +18,13 @@ runs:
   using: composite
   steps:
     - name: Checkout repository
-      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: 0
         token: ${{ github.token }}
 
     - name: Setup Node.js
-      uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
+      uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
       with:
         node-version: ${{ inputs.node-version }}
         cache: 'npm'


### PR DESCRIPTION
## Summary

- Enforce least-privilege permissions across all GitHub Actions workflows by setting top-level `permissions: {}` and adding job-level scopes only where needed
- Update `ivuorinen/actions` reusable workflows to v2026.03.09 (pr-lint, stale, sync-labels, codeql-analysis)
- Update release workflow actions: cosign-installer v4.1.0, sbom-action v0.23.1, docker-setup-buildx v4.0.0, docker-login v4.0.0
- Update testdata composite action deps: actions/checkout v6.0.2, actions/setup-node v6.3.0

## Test plan

- [ ] CI workflows pass on this PR
- [ ] CodeQL analysis runs successfully
- [ ] Release workflow syntax validates (actionlint passed in pre-commit)