### PR TITLE
fix: install commit-msg hook for local commitlint checks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,6 +153,11 @@ refactor: move inline YAML to fixtures for better test maintainability
 - Do NOT argue or explain why they might be useful
 - Just comply immediately and recommit without bylines
 
+### 🚫 Commit Messages Over 100 Characters
+
+Commitlint enforces `header-max-length: 100`. Keep commit message first lines under 100 characters.
+The `commit-msg` hook catches this locally if installed via `make pre-commit-install`.
+
 ### ✅ Prevention Mechanisms
 
 **Before writing ANY code:**

--- a/Makefile
+++ b/Makefile
@@ -139,6 +139,7 @@ pre-commit-install: ## Install pre-commit hooks
 	@command -v pre-commit >/dev/null 2>&1 || \
 		{ echo "Please install pre-commit or run 'make devtools'"; exit 1; }
 	pre-commit install
+	pre-commit install --hook-type commit-msg
 
 pre-commit-update: ## Update pre-commit hooks to latest versions
 	@echo "Updating pre-commit hooks..."


### PR DESCRIPTION
## Summary
- `pre-commit install` only installs the `pre-commit` hook, not the `commit-msg` hook — so commitlint never ran locally
- Added `pre-commit install --hook-type commit-msg` to the `pre-commit-install` Makefile target
- Documented the 100-char header limit in CLAUDE.md anti-patterns

## Test plan
- [x] `make pre-commit-install` installs both `.git/hooks/pre-commit` and `.git/hooks/commit-msg`
- [x] Commit with >100 char header is rejected locally by commitlint
- [x] Valid commit passes all hooks