### PR TITLE
ci: migrate CodeQL to ivuorinen/actions/codeql-analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,7 +1,6 @@
 ---
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 name: "CodeQL"
-
 on:
   push:
     branches: ["main"]
@@ -11,16 +10,15 @@ on:
     - cron: "30 1 * * 0"
   merge_group:
 
-permissions: {}
+permissions:
+  actions: read
+  contents: read
 
 jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
     permissions:
-      actions: read
-      contents: read
-      packages: read
       security-events: write
     strategy:
       fail-fast: false
@@ -28,7 +26,6 @@ jobs:
         language: ["actions", "go"]
     steps:
       - name: CodeQL Analysis
-        uses: ivuorinen/actions/codeql-analysis@1da3a0e79fcd7da6bed9ee1979f1449ba11f58f9 # v2026.03.14
+        uses: ivuorinen/actions/codeql-analysis@main
         with:
           language: ${{ matrix.language }}
-          queries: security-and-quality


### PR DESCRIPTION
Migrate from direct `github/codeql-action` usage to the centralized
`ivuorinen/actions/codeql-analysis` composable workflow.

This eliminates repetitive Renovate PRs for CodeQL action version bumps
by centralizing version management in the shared actions repo.