### PR TITLE
fix(ci): add go-version-file to release workflow and fix gitleaks ignores

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,12 +24,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
+          go-version-file: "go.mod"
           cache: true
-
-      - name: Set up Node.js (for cosign)
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
-        with:
-          node-version: "24"
 
       - name: Install cosign
         uses: sigstore/cosign-installer@ba7bc0a3fef59531c69a25acd34668d6d3fe6f22 # v4.1.0

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -27,6 +27,12 @@ testdata/yaml-fixtures/configs/global-config-default.yml:github-pat:4
 testutil/test_constants.go:github-pat:363
 testutil/test_constants.go:github-pat:455
 
+# config_helper_test.go test tokens (dir scan format)
+internal/config_helper_test.go:generic-api-key:99
+internal/config_helper_test.go:generic-api-key:101
+internal/config_helper_test.go:github-pat:99
+internal/config_helper_test.go:github-pat:101
+
 # config_helper_test.go test tokens (commit 6291710)
 62917109069f227e8227a25448fe8c4242405309:internal/config_helper_test.go:generic-api-key:99
 62917109069f227e8227a25448fe8c4242405309:internal/config_helper_test.go:generic-api-key:101


### PR DESCRIPTION
## Summary
- Add `go-version-file: "go.mod"` to release workflow so it uses the same Go version as CI/security workflows
- Remove unnecessary `actions/setup-node` step from release workflow (cosign uses `sigstore/cosign-installer`, not Node.js)
- Add dir-scan format `.gitleaksignore` entries for `config_helper_test.go` test tokens to fix scheduled security scan failures

## Test plan
- [ ] CI passes on this PR
- [ ] Verify release workflow YAML is valid (actionlint check in CI)
- [ ] Verify next scheduled gitleaks scan passes (Sunday 2am UTC)