### PR TITLE
fix(tests): isolate wizard tests from GITHUB_TOKEN env var

### DIFF
--- a/internal/wizard/wizard_test.go
+++ b/internal/wizard/wizard_test.go
@@ -655,8 +655,8 @@ func TestConfigureGitHubIntegration(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Setenv("GITHUB_TOKEN", "")
-			t.Setenv("GH_README_GITHUB_TOKEN", "")
+			t.Setenv(appconstants.EnvGitHubTokenStandard, "")
+			t.Setenv(appconstants.EnvGitHubToken, "")
 			wizard := testWizard(tt.inputs)
 			if tt.existingToken != "" {
 				wizard.config.GitHubToken = tt.existingToken
@@ -998,8 +998,8 @@ func TestRun(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Setenv("GITHUB_TOKEN", "")
-			t.Setenv("GH_README_GITHUB_TOKEN", "")
+			t.Setenv(appconstants.EnvGitHubTokenStandard, "")
+			t.Setenv(appconstants.EnvGitHubToken, "")
 			wizard := testWizard(tt.inputs)
 
 			config, err := wizard.Run()

--- a/internal/wizard/wizard_test.go
+++ b/internal/wizard/wizard_test.go
@@ -655,6 +655,8 @@ func TestConfigureGitHubIntegration(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("GITHUB_TOKEN", "")
+			t.Setenv("GH_README_GITHUB_TOKEN", "")
 			wizard := testWizard(tt.inputs)
 			if tt.existingToken != "" {
 				wizard.config.GitHubToken = tt.existingToken
@@ -996,6 +998,8 @@ func TestRun(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("GITHUB_TOKEN", "")
+			t.Setenv("GH_README_GITHUB_TOKEN", "")
 			wizard := testWizard(tt.inputs)
 
 			config, err := wizard.Run()


### PR DESCRIPTION
## Summary
- Clear `GITHUB_TOKEN` and `GH_README_GITHUB_TOKEN` in `TestConfigureGitHubIntegration` and `TestRun` wizard tests
- Prevents the wizard from short-circuiting past token prompts when these env vars are set in the dev environment
- Fixes input misalignment that caused "configuration canceled by user" test failures

## Test plan
- [x] All wizard tests pass locally (`go test ./internal/wizard/ -v`)
- [x] Full test suite passes (`go test ./...`)
- [ ] CI passes on this PR