### PR TITLE
fix(ci): update stale.yml to include token for actions

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,8 +16,10 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      contents: write # only for delete-branch option
+      contents: write
       issues: write
       pull-requests: write
     steps:
       - uses: ivuorinen/actions/stale@f2d15a840e8888ba4f0c348ea70b6522cf2dc541 # v2026.04.15
+        with:
+          token: ${{ github.token }}


### PR DESCRIPTION
This pull request makes a minor update to the `.github/workflows/stale.yml` workflow configuration by specifying the GitHub token for the stale action step.

* Workflow configuration:
  * Added the `token: ${{ github.token }}` input to the `ivuorinen/actions/stale` step to explicitly provide authentication credentials.