### PR TITLE
chore(go): set language floor to 1.25.0 and track toolchain go1.27.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/ivuorinen/gh-action-readme
 
-go 1.27.0
+go 1.25.0
+
+toolchain go1.27.0
 
 require (
 	github.com/adrg/xdg v0.5.3


### PR DESCRIPTION
Adds a `toolchain` directive so this module keeps receiving Go version updates.

mise is deprecating reading the `go` directive (`idiomatic.go.mod.go-directive`, removed in mise 2026.11.0), and `ivuorinen/renovate-config` no longer bumps `go`. Without a `toolchain` line this module would stop getting Go updates entirely; Renovate proposes `toolchain` updates by default.

The `go` directive is now the language-compatibility floor: 1.27.0 -> 1.25.0, settled by `go mod tidy` against the dependency graph. Verified with tidy + build + vet, and the full pre-commit suite passes including `golangci-lint-repo-mod`.

No lint bump needed — this repo already pins golangci-lint v2.13.1, which handles Go 1.27 cleanly.