### PR TITLE
fix(go): raise language floor to 1.26.4 to match the documented requirement

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ git push origin feature/my-awesome-feature
 
 ### Prerequisites
 
-- **Go 1.26.3+** (required)
+- **Go 1.26.4+** (required — matches the `go` directive in `go.mod`)
 - **golangci-lint** (for code quality)
 - **pre-commit** (for git hooks)
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ivuorinen/gh-action-readme
 
-go 1.25.0
+go 1.26.4
 
 toolchain go1.27.0
 


### PR DESCRIPTION
PR #303 set the `go` directive to `1.25.0` — what `go mod tidy` settles on against the dependency graph — without checking it against what this repository documents.

| source | claims |
| --- | --- |
| `CONTRIBUTING.md:39` | **Go 1.26.3+** (required) |
| `README.md:114` | requires Go 1.26.4+ |
| `go.mod` after #303 | `go 1.25.0` |

CI reads the `go` directive via `go-version-file`, so the merged value would build and test on an older Go than the project tells users it needs. Review caught the identical defect on `ivuorinen/gh-history#22` before it merged; this one had already landed.

**Changes**

- `go.mod`: `go 1.25.0` → `go 1.26.4`, satisfying the stricter of the two claims. `toolchain go1.27.0` unchanged.
- `CONTRIBUTING.md`: `1.26.3+` → `1.26.4+`, so the two documents agree and both point at the `go` directive.

**Verification** — pinned to the declared floor rather than `GOTOOLCHAIN=auto`, which follows the toolchain line and never exercises the floor:

```
GOTOOLCHAIN=go1.26.4 go version      go version go1.26.4 linux/amd64
GOTOOLCHAIN=go1.26.4 go build ./...  exit 0
GOTOOLCHAIN=go1.26.4 go vet ./...    exit 0
make test                            PASS
```

Full pre-commit suite passes, including `golangci-lint-repo-mod`.